### PR TITLE
Update README.md - link to spec was 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 See also (related specs):
 
-* [Authorization Capabilities for Linked Data v0.3](https://w3c-ccg.github.io/zcap-ld/)
+* [Authorization Capabilities for Linked Data v0.3](https://w3c-ccg.github.io/zcap-spec/)
 
 ## Install
 


### PR DESCRIPTION
The link to the spec. was https://w3c-ccg.github.io/zcap-ld/ which returned 404  
Changed to https://w3c-ccg.github.io/zcap-spec/