### PR TITLE
add ./dist/context.esm.js to package.json files list so it is published on npm and package.json 'module' link works

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "./dist/context.esm.js",
   "files": [
     "contexts",
+    "dist/context.esm.js",
     "dist/context.js",
     "js"
   ],


### PR DESCRIPTION
Motivation:
* resolve https://github.com/digitalbazaar/zcap-context/issues/8